### PR TITLE
obdisk: Make sure that alias is initialized in grub_obdisk_init

### DIFF
--- a/grub-core/disk/ieee1275/obdisk.c
+++ b/grub-core/disk/ieee1275/obdisk.c
@@ -758,6 +758,7 @@ add_bootpath (void)
 
   grub_ieee1275_get_boot_dev (&dev);
   type = grub_ieee1275_get_device_type (dev);
+  alias = NULL;
 
   if (!(type && grub_strcmp (type, "network") == 0))
     {


### PR DESCRIPTION
Hi Eric!

Just did another test build on Debian after some months for the first time and I found a minor issue when building with gcc-6 with ```-Werror=maybe-uninitialized```:

```bash
disk/ieee1275/obdisk.c: In function ‘grub_obdisk_init’:
disk/ieee1275/obdisk.c:782:3: error: ‘alias’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
   grub_free (alias);
   ^~~~~~~~~~~~~~~~~
disk/ieee1275/obdisk.c:756:15: note: ‘alias’ was declared here
   char *dev, *alias;
               ^~~~~
```

This can be trivially fixed by just initializing ```alias``` with ```NULL```.